### PR TITLE
#1: fixes 'Repo' link position on inner pages with image

### DIFF
--- a/_sass/jekyll-docskimmer-theme.scss
+++ b/_sass/jekyll-docskimmer-theme.scss
@@ -413,7 +413,6 @@ h1,h2,h2,h4,h5,h6{color:$blue}
 .project-list__heading{color:$darkBlue}
 
 .project-list__link {
-    clear:both;
     display:table;
     margin:0.5em 0;
     &:after {


### PR DESCRIPTION
## Changed:
* Removes CSS rule (for 'Repo' link) that caused link to display underneath screenshot/image.

Resolves #1 .