### PR TITLE
Dependabot alert: Rake

### DIFF
--- a/jekyll-docskimmer-theme.gemspec
+++ b/jekyll-docskimmer-theme.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.6"
 
   spec.add_development_dependency "bundler", ">= 2.2.33"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 end


### PR DESCRIPTION
Addresses  Dependabot alert #1 (/jekyll-docskimmer-theme/security/dependabot/1).

## Changed
* Upgrade Rake from >= v10.0 and < v10.1 to >= v12.3.3